### PR TITLE
Removes colon from test selectors to allow better control over selectors

### DIFF
--- a/lib/ruby_leiningen/commands/plugins/eftest.rb
+++ b/lib/ruby_leiningen/commands/plugins/eftest.rb
@@ -2,7 +2,8 @@ require_relative '../../commands'
 
 RubyLeiningen::Commands.define_custom_command("eftest") do |config, opts|
   only = opts[:only] ? [":only #{opts[:only]}"] : []
-  specific = (opts[:test_selectors] || []).map { |m| ":#{m}" }
+  specific = (opts[:test_selectors] || [])
+     .map { |m| m.is_a?(Symbol) ? ":#{m}" : "#{m}" }
   all = [":all"]
 
   test_selectors =

--- a/spec/ruby_leiningen/commands/plugins/eftest_spec.rb
+++ b/spec/ruby_leiningen/commands/plugins/eftest_spec.rb
@@ -59,6 +59,20 @@ describe RubyLeiningen::Commands::Eftest do
         test_selectors: [:unit, :integration])
   end
 
+  it 'allows class based test selectors' do
+    command = RubyLeiningen::Commands::Eftest.new(binary: 'lein')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with(
+                'lein eftest mylib.core mylib.helpers some.namespace/test-something :integration',
+                any_args))
+
+    command.execute(
+        namespaces: ["mylib.core", "mylib.helpers"],
+        test_selectors: ["some.namespace/test-something", :integration])
+  end
+
   it 'allows the only test selector' do
     command = RubyLeiningen::Commands::Eftest.new(binary: 'lein')
 


### PR DESCRIPTION
As shown here: https://github.com/weavejester/eftest#plugin eftest also allows for selectors that are the class or file, by removing the colon being added here we can use these as well.