### PR TITLE
Adds kondo command

### DIFF
--- a/lib/ruby_leiningen/commands/plugins/kondo.rb
+++ b/lib/ruby_leiningen/commands/plugins/kondo.rb
@@ -1,0 +1,32 @@
+require_relative '../../commands'
+
+RubyLeiningen::Commands.define_custom_command("kondo") do |config, opts|
+  path = opts[:path]
+  cache_directory = opts[:cache_directory]
+  cache = opts[:cache]
+  config_dir = opts[:config_dir]
+  parallel = opts[:parallel]
+  fail_level = opts[:fail_level]
+
+  config.on_subcommand_builder do |command|
+    unless path.nil?
+      command = command.with_option('--lint', path)
+    end
+    unless cache_directory.nil?
+      command = command.with_option('--cache-dir', cache_directory)
+    end
+    unless cache.nil?
+      command = command.with_flag('--cache')
+    end
+    unless config_dir.nil?
+      command = command.with_option('--config-dir', config_dir)
+    end
+    unless parallel.nil?
+      command = command.with_flag('--parallel')
+    end
+    unless fail_level.nil?
+      command = command.with_option('--fail-level', fail_level)
+    end
+    command
+  end
+end

--- a/spec/ruby_leiningen/commands/plugins/kondo_spec.rb
+++ b/spec/ruby_leiningen/commands/plugins/kondo_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+require_relative '../../../support/shared_examples/profile_support'
+require_relative '../../../support/shared_examples/environment_support'
+
+require_relative '../../../../lib/ruby_leiningen/commands/plugins/kondo'
+
+describe RubyLeiningen::Commands::Kondo do
+  it 'calls the lein kondo subcommand' do
+    command = RubyLeiningen::Commands::Kondo.new(binary: 'lein')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('lein kondo', any_args))
+
+    command.execute
+  end
+
+  it_behaves_like "a command with profile support", 'kondo'
+  it_behaves_like "a command with environment support", 'kondo'
+
+  it 'passes the supplied lint path' do
+    command = RubyLeiningen::Commands::Kondo.new(binary: 'lein')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('lein kondo --lint src', any_args))
+
+    command.execute(path: 'src')
+  end
+
+  it 'passes the supplied cache directory' do
+    command = RubyLeiningen::Commands::Kondo.new(binary: 'lein')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('lein kondo --cache-dir cache', any_args))
+
+    command.execute(cache_directory: 'cache')
+  end
+
+  it 'passes the supplied config directory' do
+    command = RubyLeiningen::Commands::Kondo.new(binary: 'lein')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('lein kondo --config-dir config', any_args))
+
+    command.execute(config_dir: 'config')
+  end
+
+  it 'passes the supplied fail level' do
+    command = RubyLeiningen::Commands::Kondo.new(binary: 'lein')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('lein kondo --fail-level warning', any_args))
+
+    command.execute(fail_level: 'warning')
+  end
+
+  it 'passes the supplied cache flag' do
+    command = RubyLeiningen::Commands::Kondo.new(binary: 'lein')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('lein kondo --cache', any_args))
+
+    command.execute(cache: true)
+  end
+
+  it 'passes the supplied parallel flag' do
+    command = RubyLeiningen::Commands::Kondo.new(binary: 'lein')
+
+    expect(Open4).to(
+        receive(:spawn)
+            .with('lein kondo --parallel', any_args))
+
+    command.execute(parallel: true)
+  end
+end

--- a/spec/ruby_leiningen_spec.rb
+++ b/spec/ruby_leiningen_spec.rb
@@ -177,6 +177,20 @@ RSpec.describe RubyLeiningen do
     RubyLeiningen.eastwood(profile: profile)
   end
 
+  it 'exposes a kondo helper function when kondo plugin required' do
+    profile = 'test'
+
+    kondo_command = double('kondo command')
+
+    expect(RubyLeiningen::Commands::Kondo)
+        .to(receive(:new).and_return(kondo_command))
+    expect(kondo_command)
+        .to(receive(:execute)
+                .with(profile: profile))
+
+    RubyLeiningen.kondo(profile: profile)
+  end
+
   it 'exposes an eftest helper function when eftest plugin required' do
     profile = 'test'
     namespaces = ["first.namespace", "second.namespace"]


### PR DESCRIPTION
This might still need a bit of work so putting it as draft state for now.

There's a bit of an issue as the normal kondo command is `clj-kondo` which breaks the generation of the command via `define_custom_command`. At present, we could make this work by having a profile that specified that the command name is `kondo` in the `project.clj` but this seems like a bit of a workaround.

Secondly (and in retrospect this might also be the case for the `cljstyle` task), clj-kondo recommends you run it from the compiled binary due to the speed benefits, which if we go off the above we won't get, and I'm not sure if we've accounted for this or want to do something slightly different for these two tasks as a result.